### PR TITLE
Remove X-Application-Version header

### DIFF
--- a/src/ngx_http_security_headers_module.c
+++ b/src/ngx_http_security_headers_module.c
@@ -225,6 +225,11 @@ ngx_http_security_headers_filter(ngx_http_request_t *r)
         ngx_str_set(&key, "x-varnish");
         ngx_str_set(&val, "");
         ngx_set_headers_out_by_search(r, &key, &val);
+        
+        /* Hide X-Application-Version */
+        ngx_str_set(&key, "x-application-version");
+        ngx_str_set(&val, "");
+        ngx_set_headers_out_by_search(r, &key, &val);
     }
 
     if (1 != slcf->enable) {


### PR DESCRIPTION
Some applications may use this header to output the client/software versions which is potentially a risk for vulnerability identification/information gathering.