### PR TITLE
Add --with-compat to ./configure instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ load_module modules/ngx_http_modsecurity_module.so;
 To compile the module into NGINX, run:
 
 ```bash
-./configure --add-module=../ngx_security_headers
+./configure --with-compat --add-module=../ngx_security_headers
 make 
 make install
 ```


### PR DESCRIPTION
For dynamic module loading, building from the NGINX source using `--with-compat` is highly recommended. Doing this allows you to use the dynamic module. You technically only need to run make and then copy the .so from objs, rather than a full make install but to actually load the module it needs to have `--with-compat` otherwise you'll get a binary error when loading.