### PR TITLE
docs: fix typo in security_headers_xss syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ A special value `omit` disables sending a particular header by the module (usefu
 
 ### `security_headers_xss`
 
-- **syntax**: `security_headers off | on | block | omit`
+- **syntax**: `security_headers_xss off | on | block | omit`
 - **default**: `block`
 - **context**: `http`, `server`, `location`
 


### PR DESCRIPTION
Fixing a small typo in the README