### PR TITLE
Update HTTP Strict Transport Security (HSTS) max-age value

### DIFF
--- a/src/ngx_http_security_headers_module.c
+++ b/src/ngx_http_security_headers_module.c
@@ -272,9 +272,9 @@ ngx_http_security_headers_filter(ngx_http_request_t *r)
     {
         ngx_str_set(&key, "Strict-Transport-Security");
         if (1 == slcf->hsts_preload) {
-            ngx_str_set(&val, "max-age=63072000; includeSubDomains; preload");
+            ngx_str_set(&val, "max-age=31536000; includeSubDomains; preload");
         } else {
-            ngx_str_set(&val, "max-age=63072000; includeSubDomains");
+            ngx_str_set(&val, "max-age=31536000; includeSubDomains");
         }
         ngx_set_headers_out_by_search(r, &key, &val);
     }


### PR DESCRIPTION
Set to 31536000 as recommended by OWASP, Qualys and others.

https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html
https://blog.qualys.com/vulnerabilities-threat-research/2016/03/28/the-importance-of-a-proper-http-strict-transport-security-implementation-on-your-web-server
