### PR TITLE
ci: add cppcheck + AddressSanitizer + CodeQL quality CI

### DIFF
--- a/.cppcheck-suppressions
+++ b/.cppcheck-suppressions
@@ -1,0 +1,16 @@
+// cppcheck suppressions for ngx_http_security_headers_module.
+// Keep this list tight: suppress noise, never a real bug. If cppcheck flags a
+// genuine issue, fix the code rather than adding a line here.
+
+// nginx headers are pulled in via -I system paths; we don't want cppcheck
+// reporting on or descending into them.
+missingIncludeSystem
+
+// Module entry points (handlers, directive setters, init/exit callbacks) are
+// referenced only through nginx's static command/module tables, so cppcheck
+// cannot see the call sites and reports them as unused.
+unusedFunction
+
+// Avoid failing the build when a suppression above stops matching after a
+// refactor; surfaced as information, reviewed when tuning this file.
+unmatchedSuppression

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,6 @@
+name: "CodeQL config for ngx_http_security_headers_module"
+
+# CodeQL builds the whole nginx tree to analyze our module, but we only care
+# about findings in code we own. Restrict reported paths to the module sources.
+paths:
+  - "src/"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,3 +44,52 @@ jobs:
       - name: Test the module
         run: |
           PATH=$(pwd)/nginx/objs:$PATH PERL5LIB=$HOME/perl5/lib/perl5 TEST_NGINX_VERBOSE=true prove -v
+
+  test-asan:
+    runs-on: ubuntu-latest
+    env:
+      NGINX_VERSION: release-1.27.2
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install build and test dependencies
+        run: |
+          sudo apt-get --yes update
+          sudo apt-get install --yes libpcre3-dev libssl-dev zlib1g-dev perl cpanminus git
+
+      - name: Install Test::Nginx
+        run: |
+          cpanm --notest --local-lib=$HOME/perl5 Test::Nginx Test::Nginx::Socket
+
+      - name: Build nginx with the module statically under AddressSanitizer
+        run: |
+          git clone --depth 1 --branch "${NGINX_VERSION}" \
+            https://github.com/nginx/nginx.git /tmp/nginx-src
+          cd /tmp/nginx-src
+          ./auto/configure --with-debug --with-compat \
+            --add-module="${GITHUB_WORKSPACE}" \
+            --with-cc-opt="-fsanitize=address -fno-omit-frame-pointer -g" \
+            --with-ld-opt="-fsanitize=address"
+          make -j"$(nproc)"
+
+      - name: Run test suite under AddressSanitizer
+        # detect_leaks=0 — nginx leaves benign allocations live at the point
+        # Test::Nginx kills it. The post-run grep below catches real ASan
+        # reports written to /tmp/asan/asan.* even when prove returns 0.
+        env:
+          TEST_NGINX_BINARY: /tmp/nginx-src/objs/nginx
+          ASAN_OPTIONS: detect_leaks=0:abort_on_error=1:log_path=/tmp/asan/asan
+        run: |
+          mkdir -p /tmp/asan
+          export PATH=/tmp/nginx-src/objs:$PATH PERL5LIB=$HOME/perl5/lib/perl5
+          set +e
+          prove -v t/*.t
+          rc=$?
+          set -e
+          if grep -q "AddressSanitizer\|runtime error" /tmp/asan/asan.* 2>/dev/null; then
+            echo "::error::AddressSanitizer / UBSan reports detected"
+            cat /tmp/asan/asan.* >&2
+            exit 1
+          fi
+          exit $rc

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,77 @@
+name: Static Analysis
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  cppcheck:
+    runs-on: ubuntu-latest
+    env:
+      NGINX_VERSION: release-1.27.2
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cppcheck and nginx build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cppcheck \
+            build-essential libpcre3-dev libssl-dev zlib1g-dev git
+
+      - name: Fetch nginx headers
+        run: |
+          git clone --depth 1 --branch "${NGINX_VERSION}" \
+            https://github.com/nginx/nginx.git /tmp/nginx-src
+          cd /tmp/nginx-src
+          ./auto/configure --with-debug --with-compat
+
+      - name: Run cppcheck
+        run: |
+          cppcheck --enable=warning,portability,performance \
+            --check-level=exhaustive \
+            --error-exitcode=1 \
+            --suppressions-list=.cppcheck-suppressions \
+            --suppress=missingIncludeSystem \
+            --std=c11 \
+            -I /tmp/nginx-src/src/core -I /tmp/nginx-src/src/event \
+            -I /tmp/nginx-src/src/http -I /tmp/nginx-src/src/http/modules \
+            -I /tmp/nginx-src/src/os/unix -I /tmp/nginx-src/objs \
+            src/ngx_http_security_headers_module.c
+
+  codeql:
+    runs-on: ubuntu-latest
+    # Public repo: real upload to the Security tab; permissions: security-events
+    # needs write.
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    env:
+      NGINX_VERSION: release-1.27.2
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: c-cpp
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Build nginx with the module (static)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential \
+            libpcre3-dev libssl-dev zlib1g-dev git
+          git clone --depth 1 --branch "${NGINX_VERSION}" \
+            https://github.com/nginx/nginx.git /tmp/nginx-src
+          cd /tmp/nginx-src
+          ./auto/configure --with-compat \
+            --add-module="${GITHUB_WORKSPACE}"
+          make -j"$(nproc)"
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /nbproject
 /t/servroot
+CLAUDE.md
+.cursor/
+test-error.log


### PR DESCRIPTION
## Summary

Brings this module up to the quality bar established by [`ngx_nftset_access_module` PR #1](https://github.com/GetPageSpeed/ngx_nftset_access_module/pull/1). **Runner-direct** path (no Docker base image) — the existing `build.yml` already follows that pattern, so less new infrastructure to maintain.

- **cppcheck** — `static-analysis.yml`'s `cppcheck` job apt-installs cppcheck, git-clones the same `release-1.27.2` nginx tree the test workflow uses, configures it so headers resolve under `/tmp/nginx-src/objs`, then lints `src/ngx_http_security_headers_module.c` at `--check-level=exhaustive`. `.cppcheck-suppressions` only mutes noise (`missingIncludeSystem`, `unusedFunction`, `unmatchedSuppression`).
- **AddressSanitizer** — new `test-asan` job in `build.yml`. Rebuilds nginx with `--add-module` (static) under `-fsanitize=address`, runs the existing Test::Nginx suite. `detect_leaks=0` avoids benign LSAN false positives at shutdown; post-`prove` the step greps `/tmp/asan/asan.*` and fails on any report.
- **CodeQL** — `static-analysis.yml`'s `codeql` job. This is a **public** repo, so `analyze@v3` uploads SARIF normally to the Security tab; `permissions: { security-events: write }` — the regular path, not the private-repo `upload: never` + SARIF gate. Important to validate this branch of the quality-CI pattern in week 1 of the rollout.

Also tightens `.gitignore` for `CLAUDE.md`, `.cursor/`, `test-error.log` so the working tree stays clean across sessions.

## Test plan

- [x] cppcheck (ad-hoc, via the sibling sorted_args base image which already had cppcheck + nginx headers cached) — clean (zero findings).
- [x] ASAN suite (ad-hoc, same image): 108 tests pass across `config.t` + `headers.t`, exit 0, zero ASAN/UBSan reports.
- [ ] CI passes: existing `build` matrix (stable + mainline), new `test-asan`, `cppcheck`, `codeql` (with upload to Security tab).

Part of the weekly GetPageSpeed nginx-module quality-CI rollout. First public repo in the rollout.